### PR TITLE
remove rebar warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,18 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.
-{port_sources, [{"darwin", ["c_src/*.c"]}, {"linux", ["c_src/*.c"]}]}.
-{port_envs, [{"linux", "LDFLAGS", "$LDFLAGS -ldns_sd"}]}.
 {erl_opts, [debug_info,
 	    {platform_define, "(R14|R15)", 'warnings_as_errors'},
 	    {platform_define, "(linux|bsd)", 'AVAHI'}]}.
-{pre_hooks, [{compile, "escript winbuild.escript"}]}.
 {edoc_opts, [{overview, "overview.edoc"}, {dir, "doc"}]}.
 {eunit_opts, [verbose]}.
+
+
+{port_specs, [{"linux", "priv/dnssd_drv.so", ["c_src/*.c"]},
+              {"darwin", "priv/dnssd_drv.so", ["c_src/*.c"]}]}.
+{port_env, [{"linux", "LDFLAGS", "$LDFLAGS -ldns_sd"}]}.
+
+{pre_hooks, [{compile, "escript winbuild.escript"}]}.
+


### PR DESCRIPTION
port_envs and port_sources have been deprecated in latest rebar. This patch fix it.
