### PR TITLE
Fix runtime typechecks

### DIFF
--- a/c_src/dnssd.c
+++ b/c_src/dnssd.c
@@ -203,7 +203,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
       goto badarg;
     }
   } else if (cmd == DNSSD_CMD_BROWSE) {
-    if (!arg.ei_type == ERL_TUPLE || arg.arity != 2) goto badarg;
+    if (arg.ei_type != ERL_SMALL_TUPLE_EXT || arg.arity != 2) goto badarg;
     /* decode type */
     ei_decode_ei_term(buf, &index, &type);
     if (type.ei_type != ERL_BINARY_EXT) goto badarg;
@@ -232,7 +232,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
     driver_free(type_tmp);
     driver_free(domain_tmp);
   } else if (cmd == DNSSD_CMD_RESOLVE) {
-    if (!arg.ei_type == ERL_TUPLE || arg.arity != 3) goto badarg;
+    if (arg.ei_type != ERL_SMALL_TUPLE_EXT || arg.arity != 3) goto badarg;
     /* decode name */
     ei_decode_ei_term(buf, &index, &name);
     if (name.ei_type != ERL_BINARY_EXT) goto badarg;
@@ -276,7 +276,7 @@ static ErlDrvSSizeT call(ErlDrvData edd, unsigned int cmd, char *buf,
     driver_free(type_tmp);
     driver_free(domain_tmp);
   } else if (cmd == DNSSD_CMD_REGISTER) {
-    if (!arg.ei_type == ERL_TUPLE || arg.arity != 6) goto badarg;
+    if (arg.ei_type != ERL_SMALL_TUPLE_EXT || arg.arity != 6) goto badarg;
     /* decode name */
     ei_decode_ei_term(buf, &index, &name);
     if (name.ei_type != ERL_BINARY_EXT) goto badarg;


### PR DESCRIPTION
This patch fixes the issue mentioned in #12 and associated compile time warnings.

ERL_TUPLE is a type tag which can be bitwise 'or'ed into values, ERL_{SMALL,LARGE}_TUPLE_EXT is External Term Format type qualifier: http://erlang.org/doc/apps/erts/erl_ext_dist.html#id100449